### PR TITLE
Pose estimation NumPy compatibility fixes

### DIFF
--- a/src/opendr/perception/pose_estimation/dependencies.ini
+++ b/src/opendr/perception/pose_estimation/dependencies.ini
@@ -6,7 +6,7 @@ python=torch==1.7.1
        tensorboardX==2.0
        opencv-python==4.5.1.48
        matplotlib==2.2.2
-       git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI
+       git+https://github.com/cidl-auth/cocoapi#subdirectory=PythonAPI
        tqdm==4.54.0
        onnx==1.8.0
        onnxruntime==1.3.0


### PR DESCRIPTION
This PR updates the requirements of pose estimation in order to use a patched version of the (already modified in order to work on windows) pycocotools. This fixes the issue reported in #87 and makes the implementation compatible with any NumPy version.