### PR TITLE
Fix issue 103

### DIFF
--- a/tests/sources/tools/perception/activity_recognition/cox3d/test_cox3d_learner.py
+++ b/tests/sources/tools/perception/activity_recognition/cox3d/test_cox3d_learner.py
@@ -109,11 +109,11 @@ class TestCoX3DLearner(unittest.TestCase):
 
         # Input is Image
         results2 = self.learner.infer(Image(batch[0], dtype=np.float))
-        assert torch.allclose(results1[0].confidence, results2[0].confidence)
+        assert torch.allclose(results1[0].confidence, results2[0].confidence, atol=1e-6)
 
         # Input is List[Image]
         results3 = self.learner.infer([Image(v, dtype=np.float) for v in batch])
-        assert all([torch.allclose(r1.confidence, r3.confidence) for (r1, r3) in zip(results1, results3)])
+        assert all([torch.allclose(r1.confidence, r3.confidence, atol=1e-6) for (r1, r3) in zip(results1, results3)])
 
     def test_optimize(self):
         self.learner.ort_session = None

--- a/tests/sources/tools/perception/activity_recognition/x3d/test_x3d_learner.py
+++ b/tests/sources/tools/perception/activity_recognition/x3d/test_x3d_learner.py
@@ -107,12 +107,12 @@ class TestX3DLearner(unittest.TestCase):
         # Input is Video
         results2 = self.learner.infer(Video(batch[0]))
         assert results1[0].data == results2[0].data
-        assert torch.allclose(results1[0].confidence, results2[0].confidence)
+        assert torch.allclose(results1[0].confidence, results2[0].confidence, atol=1e-6)
 
         # Input is List[Video]
         results3 = self.learner.infer([Video(v) for v in batch])
         assert all([
-            r1.data == r3.data and torch.allclose(r1.confidence, r3.confidence)
+            r1.data == r3.data and torch.allclose(r1.confidence, r3.confidence, atol=1e-6)
             for (r1, r3) in zip(results1, results3)
         ])
 


### PR DESCRIPTION
This PR increases the tolerance associated with the X3D and CoX3D test value-checks, that were found to occasionally fail on some platforms. See #103 for more information.
With the new absolute tolerance (old: 1e-8; new: 1e-6), it is highly unlikely that numerical issues should make the test fail.
