### PR TITLE
Use pip -r to install python dependencies

### DIFF
--- a/bin/setup.bash
+++ b/bin/setup.bash
@@ -8,3 +8,4 @@ if [[ ! -d "venv" ]]; then
 	virtualenv -p python3 venv
 fi
 source venv/bin/activate
+python -m pip install -U pip

--- a/dependencies/dependencies.ini
+++ b/dependencies/dependencies.ini
@@ -4,6 +4,6 @@
 python=
 
 [compilation]
-python=numpy==1.17.5
+python=numpy
        cython
        torch==1.7.1

--- a/dependencies/dependencies.ini
+++ b/dependencies/dependencies.ini
@@ -2,3 +2,4 @@
 # 'python' and 'python-dependencies' keys expects a value in the Python requirements file format
 #  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 python=torch==1.7.1
+       wheel

--- a/dependencies/dependencies.ini
+++ b/dependencies/dependencies.ini
@@ -1,9 +1,4 @@
 [runtime]
-# 'python' key expects a value in the Python requirements file format
-#  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format 
-python=
-
-[compilation]
-python=numpy
-       cython
-       torch==1.7.1
+# 'python' and 'python-dependencies' keys expects a value in the Python requirements file format
+#  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+python=torch==1.7.1

--- a/dependencies/dependencies.ini
+++ b/dependencies/dependencies.ini
@@ -1,6 +1,9 @@
 [runtime]
 # 'python' key expects a value in the Python requirements file format
 #  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format 
+python=
+
+[compilation]
 python=numpy==1.17.5
        cython
-
+       torch==1.7.1

--- a/dependencies/install.sh
+++ b/dependencies/install.sh
@@ -13,10 +13,32 @@ fi
 # Required to parse the dependency files
 pip install ConfigParser
 
-python parse_dependencies.py $TYPE
-if [ -f "python_dependencies.txt" ]; then
-       pip install -r python_dependencies.txt
-fi
+# Install global dependencies
+python parse_dependencies.py $TYPE --global
 if [ -f "linux_dependencies.txt" ]; then
        cat linux_dependencies.txt | xargs sudo apt-get install
+       rm linux_dependencies.txt
+fi
+if [ -f "python_prerequisites.txt" ]; then
+       pip install -r python_prerequisites.txt
+       rm python_prerequisites.txt
+fi
+if [ -f "python_dependencies.txt" ]; then
+       pip install -r python_dependencies.txt
+       rm python_dependencies.txt
+fi
+
+# Install the dependencies from the work packages
+python parse_dependencies.py $TYPE
+if [ -f "linux_dependencies.txt" ]; then
+       cat linux_dependencies.txt | xargs sudo apt-get install
+       rm linux_dependencies.txt
+fi
+if [ -f "python_prerequisites.txt" ]; then
+       pip install -r python_prerequisites.txt
+       rm python_prerequisites.txt
+fi
+if [ -f "python_dependencies.txt" ]; then
+       pip install -r python_dependencies.txt
+       rm python_dependencies.txt
 fi

--- a/dependencies/install.sh
+++ b/dependencies/install.sh
@@ -13,9 +13,8 @@ fi
 pip install ConfigParser numpy cython
 
 python parse_dependencies.py $TYPE
-# install dependencies one by one to prevent interdependency errors
 if [ -f "python_dependencies.txt" ]; then
-       cat python_dependencies.txt | sed -e '/^\s*#.*$/d' -e '/^\s*$/d' | xargs -n 1 python -m pip install
+       python -m pip install -r python_dependencies.txt
 fi
 if [ -f "linux_dependencies.txt" ]; then
        cat linux_dependencies.txt | xargs sudo apt-get install

--- a/dependencies/install.sh
+++ b/dependencies/install.sh
@@ -10,11 +10,12 @@ if [ "$#" -ge 1 ]; then
        TYPE=$1
 fi
 
-pip install ConfigParser numpy cython
+# Required to parse the dependency files
+pip install ConfigParser
 
 python parse_dependencies.py $TYPE
 if [ -f "python_dependencies.txt" ]; then
-       python -m pip install -r python_dependencies.txt
+       pip install -r python_dependencies.txt
 fi
 if [ -f "linux_dependencies.txt" ]; then
        cat linux_dependencies.txt | xargs sudo apt-get install

--- a/dependencies/parse_dependencies.py
+++ b/dependencies/parse_dependencies.py
@@ -59,7 +59,7 @@ if os.path.exists(linux_file):
 read_ini('dependencies.ini')
 # Loop through tools and extract dependencies
 opendr_home = os.environ.get('OPENDR_HOME')
-for subdir, dirs, files in os.walk(opendr_home + '/src'):
+for subdir, dirs, files in os.walk(os.path.join(opendr_home, 'src')):
     for filename in files:
         if filename == 'dependencies.ini':
-            read_ini(subdir + os.sep + filename)
+            read_ini(os.path.join(subdir, filename))

--- a/dependencies/parse_dependencies.py
+++ b/dependencies/parse_dependencies.py
@@ -21,6 +21,7 @@ import os
 import sys
 from configparser import ConfigParser
 
+python_prerequisites_file = "python_prerequisites.txt"
 python_file = "python_dependencies.txt"
 linux_file = "linux_dependencies.txt"
 
@@ -28,18 +29,16 @@ linux_file = "linux_dependencies.txt"
 def read_ini(path):
     parser = ConfigParser()
     parser.read(path)
-    if parser.has_option(section, 'python'):
-        python_dependencies = parser.get(section, 'python')
-        if python_dependencies:
-            for package in python_dependencies.split('\n'):
-                with open(python_file, "a") as f:
-                    f.write(os.path.expandvars(package) + '\n')
-    if parser.has_option(section, 'linux'):
-        linux_dependencies = parser.get(section, 'linux')
-        if linux_dependencies:
-            for package in linux_dependencies.split():
-                with open(linux_file, "a") as f:
-                    f.write(os.path.expandvars(package) + '\n')
+    def read_ini_key(key, summary_file):
+        if parser.has_option(section, key):
+            dependencies = parser.get(section, key)
+            if dependencies:
+                for package in dependencies.split('\n'):
+                    with open(summary_file, "a") as f:
+                        f.write(os.path.expandvars(package) + '\n')
+    read_ini_key('python-dependencies', python_prerequisites_file)
+    read_ini_key('python', python_file)
+    read_ini_key('linux', linux_file)
 
 
 # Parse arguments
@@ -48,8 +47,11 @@ if len(sys.argv) > 1:
     section = sys.argv[1]
 if section not in ["runtime", "compilation"]:
     sys.exit("Invalid dependencies type: " + section + ".\nExpected: [runtime, compilation]")
+global_dependencies = True if '--global' in sys.argv else False
 
 # Clear dependencies
+if os.path.exists(python_prerequisites_file):
+    os.remove(python_prerequisites_file)
 if os.path.exists(python_file):
     os.remove(python_file)
 if os.path.exists(linux_file):
@@ -58,8 +60,9 @@ if os.path.exists(linux_file):
 # Extract generic dependencies
 read_ini('dependencies.ini')
 # Loop through tools and extract dependencies
-opendr_home = os.environ.get('OPENDR_HOME')
-for subdir, dirs, files in os.walk(os.path.join(opendr_home, 'src')):
-    for filename in files:
-        if filename == 'dependencies.ini':
-            read_ini(os.path.join(subdir, filename))
+if not global_dependencies:
+    opendr_home = os.environ.get('OPENDR_HOME')
+    for subdir, dirs, files in os.walk(os.path.join(opendr_home, 'src')):
+        for filename in files:
+            if filename == 'dependencies.ini':
+                read_ini(os.path.join(subdir, filename))

--- a/dependencies/parse_dependencies.py
+++ b/dependencies/parse_dependencies.py
@@ -31,15 +31,15 @@ def read_ini(path):
     if parser.has_option(section, 'python'):
         python_dependencies = parser.get(section, 'python')
         if python_dependencies:
-            for package in python_dependencies.split():
-                f = open(python_file, "a")
-                f.write(package + '\n')
+            for package in python_dependencies.split('\n'):
+                with open(python_file, "a") as f:
+                    f.write(os.path.expandvars(package) + '\n')
     if parser.has_option(section, 'linux'):
         linux_dependencies = parser.get(section, 'linux')
         if linux_dependencies:
             for package in linux_dependencies.split():
-                f = open(linux_file, "a")
-                f.write(package + '\n')
+                with open(linux_file, "a") as f:
+                    f.write(os.path.expandvars(package) + '\n')
 
 
 # Parse arguments

--- a/src/opendr/perception/activity_recognition/dependencies.ini
+++ b/src/opendr/perception/activity_recognition/dependencies.ini
@@ -5,7 +5,7 @@ python=torch==1.7.1
        torchvision==0.8.2
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime==1.3.0
+       onnxruntime>=1.3.0
        pytorch_lightning==1.2.3
        av==8.0.1
        joblib==1.0.1

--- a/src/opendr/perception/activity_recognition/dependencies.ini
+++ b/src/opendr/perception/activity_recognition/dependencies.ini
@@ -5,7 +5,7 @@ python=torch==1.7.1
        torchvision==0.8.2
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime>=1.3.0
+       onnxruntime==1.3.0
        pytorch_lightning==1.2.3
        av==8.0.1
        joblib==1.0.1

--- a/src/opendr/perception/face_recognition/dependencies.ini
+++ b/src/opendr/perception/face_recognition/dependencies.ini
@@ -4,7 +4,7 @@
 python=torch==1.7.1
        torchvision==0.8.2
        tensorboard==2.3.0
-       PIL==7.0.0
+       pillow==7.0.0
        opencv-python==4.5.1.48
        matplotlib==2.2.2
        tqdm==4.54.0

--- a/src/opendr/perception/face_recognition/dependencies.ini
+++ b/src/opendr/perception/face_recognition/dependencies.ini
@@ -3,7 +3,7 @@
 #  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format 
 python=torch==1.7.1
        torchvision==0.8.2
-       tensorboard==2.3.0
+       tensorboard>=2.3.0
        pillow==7.0.0
        opencv-python==4.5.1.48
        matplotlib==2.2.2

--- a/src/opendr/perception/face_recognition/dependencies.ini
+++ b/src/opendr/perception/face_recognition/dependencies.ini
@@ -9,6 +9,6 @@ python=torch==1.7.1
        matplotlib==2.2.2
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime==1.5.2
+       onnxruntime==1.3.0
        bcolz==1.2.1
 

--- a/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/dependencies.ini
+++ b/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/dependencies.ini
@@ -8,7 +8,7 @@ python=torch==1.7.1
        matplotlib==2.2.2
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime==1.3.0
+       onnxruntime>=1.3.0
        protobuf==3.11.3
        pybind11==2.6.2
        llvmlite==0.31.0

--- a/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/dependencies.ini
+++ b/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/dependencies.ini
@@ -8,7 +8,7 @@ python=torch==1.7.1
        matplotlib==2.2.2
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime>=1.3.0
+       onnxruntime==1.3.0
        protobuf==3.11.3
        pybind11==2.6.2
        llvmlite==0.31.0

--- a/src/opendr/perception/object_tracking_2d/fair_mot/dependencies.ini
+++ b/src/opendr/perception/object_tracking_2d/fair_mot/dependencies.ini
@@ -1,8 +1,8 @@
 [runtime]
-# 'python' key expects a value using the Python requirements file format
-#  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format 
-python=torch==1.7.1
-       torchvision==0.8.2
+# 'python' and 'python-dependencies' keys expect a value in the Python requirements file format
+#  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+python-dependencies=torch==1.7.1
+python=torchvision==0.8.2
        tensorboardX==2.0
        opencv-python==4.5.1.48
        matplotlib==2.2.2

--- a/src/opendr/perception/object_tracking_2d/fair_mot/dependencies.ini
+++ b/src/opendr/perception/object_tracking_2d/fair_mot/dependencies.ini
@@ -8,7 +8,7 @@ python=torch==1.7.1
        matplotlib==2.2.2
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime==1.3.0
+       onnxruntime>=1.3.0
        git+https://github.com/MatthewHowe/DCNv2
        yacs==0.1.8
        progress==1.5

--- a/src/opendr/perception/object_tracking_2d/fair_mot/dependencies.ini
+++ b/src/opendr/perception/object_tracking_2d/fair_mot/dependencies.ini
@@ -8,7 +8,7 @@ python=torch==1.7.1
        matplotlib==2.2.2
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime>=1.3.0
+       onnxruntime==1.3.0
        git+https://github.com/MatthewHowe/DCNv2
        yacs==0.1.8
        progress==1.5

--- a/src/opendr/perception/pose_estimation/dependencies.ini
+++ b/src/opendr/perception/pose_estimation/dependencies.ini
@@ -1,6 +1,7 @@
 [runtime]
-# 'python' key expects a value using the Python requirements file format
+# 'python' and 'python-dependencies' keys expect a value in the Python requirements file format
 #  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format 
+python-dependencies=cython
 python=torch==1.7.1
        torchvision==0.8.2
        tensorboardX==2.0

--- a/src/opendr/perception/pose_estimation/dependencies.ini
+++ b/src/opendr/perception/pose_estimation/dependencies.ini
@@ -9,5 +9,5 @@ python=torch==1.7.1
        git+https://github.com/cidl-auth/cocoapi#subdirectory=PythonAPI
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime>=1.3.0
+       onnxruntime==1.3.0
 

--- a/src/opendr/perception/pose_estimation/dependencies.ini
+++ b/src/opendr/perception/pose_estimation/dependencies.ini
@@ -9,5 +9,5 @@ python=torch==1.7.1
        git+https://github.com/cidl-auth/cocoapi#subdirectory=PythonAPI
        tqdm==4.54.0
        onnx==1.8.0
-       onnxruntime==1.3.0
+       onnxruntime>=1.3.0
 


### PR DESCRIPTION
Changes proposed in this PR:
- Instead of installing python dependencies one-by-one, use `pip -r requirements.txt` to point out conflicting versions of python dependencies. The previous version silently overwrote already installed versions giving rise to undetected bugs. See #110
- Add support to install local packages via pip and specifying their location using the `OPENDR_HOME` environment variable. For instance, it is possible to use this line in the respective `dependency.ini` file:
`-e ${OPENDR_HOME}/src/opendr/perception/panoptic_segmentation/efficient_ps/algorithm/EfficientPS`
- Introduce python prerequisite dependencies since external code might rely on packages for a successful installation. For instance, [inplace_abn](https://github.com/mapillary/inplace_abn) requires `torch` to be installed beforehand. I moved these dependencies from the `install.sh` file to the global `dependencies.ini` file. **If accepted, the wiki has to be changed accordingly.**
- Minor change: correcting #109 and some inconsistent dependencies _(all related tests are passing)_

~This PR breaks a lot of the existing code since previously there were no rigorous checks to determine inconsistencies between the integrated tools. However, I would recommend reconsidering this decision to ensure easy usage of the toolkit.
Please let me know how we want to proceed with this problem.~