### PR TITLE
Lower ram load

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -48,8 +48,42 @@ jobs:
         export OPENDR_DEVICE=cpu
         pip install -r tests/requirements.txt
         python -m unittest discover -s tests
-  test-tools:
+  test-dependencies:
     needs: cleanup-runs
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        include:
+          - os: ubuntu-18.04
+            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
+            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
+            ROS_DISTRO: "melodic"
+          - os: ubuntu-20.04
+            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
+            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
+            ROS_DISTRO: "noetic"
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Test Dependencies
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
+      run: |
+        ${{ matrix.DEPENDENCIES_INSTALLATION }}
+        export OPENDR_HOME=$PWD
+        export OPENDR_DEVICE=cpu
+        export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
+        export DISABLE_BCOLZ_AVX2=true
+        export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
+        make install_compilation_dependencies
+        make install_runtime_dependencies
+        pip install -r tests/sources/requirements.txt
+  test-tools:
+    needs: test-dependencies
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
       matrix:
@@ -73,33 +107,11 @@ jobs:
           - simulation/human_model_generation
           - perception/facial_expression_recognition/landmark_based_facial_expression_recognition
           # - perception/object_tracking_3d
-        include:
-          - os: ubuntu-20.04
-            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
-            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
     - name: Test Tools
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
       run: |
-        ${{ matrix.DEPENDENCIES_INSTALLATION }}
-        export OPENDR_HOME=$PWD
-        export OPENDR_DEVICE=cpu
-        export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
-        export DISABLE_BCOLZ_AVX2=true
-        export ROS_DISTRO=noetic
-        make install_compilation_dependencies
-        make install_runtime_dependencies
-        pip install -r tests/sources/requirements.txt
-        if [ ${{ matrix.package }} = "ctests" ]; then
-            make ctests
-        else
-            source tests/sources/tools/control/mobile_manipulation/run_ros.sh
-            python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
-        fi
+        source tests/sources/tools/control/mobile_manipulation/run_ros.sh
+        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
 

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -50,7 +50,7 @@ jobs:
         python -m unittest discover -s tests
   test-tools:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception' || contains(github.event.pull_request.labels.*.name, 'test control' || contains(github.event.pull_request.labels.*.name, 'test simulation')}}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception') || contains(github.event.pull_request.labels.*.name, 'test control') || contains(github.event.pull_request.labels.*.name, 'test simulation') }}
     strategy:
       max-parallel: 10
       matrix:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -103,6 +103,11 @@ jobs:
           # - perception/object_tracking_3d
     runs-on: ${{ matrix.os }}
     steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - name: Test Perception Tools
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
       run:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -87,26 +87,26 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         package:
-          - activity_recognition
-          - compressive_learning
-          - face_recognition
-          - heart_anomaly_detection
-          - multimodal_human_centric
-          - object_tracking_2d
-          - object_detection_3d
-          - pose_estimation
-          - speech_recognition
-          - skeleton_based_action_recognition
-          - semantic_segmentation
-          - object_detection_2d
-          - facial_expression_recognition/landmark_based_facial_expression_recognition
+          - perception/activity_recognition
+          - perception/compressive_learning
+          - perception/face_recognition
+          - perception/heart_anomaly_detection
+          - perception/multimodal_human_centric
+          - perception/object_tracking_2d
+          - perception/object_detection_3d
+          - perception/pose_estimation
+          - perception/speech_recognition
+          - perception/skeleton_based_action_recognition
+          - perception/semantic_segmentation
+          - perception/object_detection_2d
+          - perception/facial_expression_recognition/landmark_based_facial_expression_recognition
           # - perception/object_tracking_3d
     runs-on: ${{ matrix.os }}
     steps:
     - name: Test Perception Tools
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
       run:
-        python -m unittest discover -s tests/sources/tools/perception/${{ matrix.package }}
+        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
   test-control:
     needs: test-dependencies
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
@@ -114,14 +114,14 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         package:
-          - mobile_manipulation
+          - control/mobile_manipulation
     runs-on: ${{ matrix.os }}
     steps:
     - name: Test Control Tools
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
       run:
         source tests/sources/tools/control/mobile_manipulation/run_ros.sh
-        python -m unittest discover -s tests/sources/tools/control/${{ matrix.package }}
+        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
   test-simulation:
     needs: test-dependencies
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
@@ -129,10 +129,10 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         package:
-          - human_model_generation
+        - simulation/human_model_generation
     runs-on: ${{ matrix.os }}
     steps:
     - name: Test Simulation Tools
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
       run:
-        python -m unittest discover -s tests/sources/tools/simulation/${{ matrix.package }}
+        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -1,4 +1,4 @@
-name: Test Suite
+name: Test Sources
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') || contains(github.event.pull_request.labels.*.name, 'test dependencies')}}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -48,27 +48,16 @@ jobs:
         export OPENDR_DEVICE=cpu
         pip install -r tests/requirements.txt
         python -m unittest discover -s tests
-  test-perception:
+  test-tools:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        include:
-          - os: ubuntu-20.04
-            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
-            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
-            export OPENDR_DEVICE=cpu
-            export OPENDR_HOME=$PWD
-            export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
-            export DISABLE_BCOLZ_AVX2=true
-            export ROS_DISTRO="noetic"
-            make install_compilation_dependencies
-            make install_runtime_dependencies
-            pip install -r tests/sources/requirements.txt
-        package:
+        engine-package:
           - engine
           - utils
+        perception-package:
           - perception/activity_recognition
           - perception/compressive_learning
           - perception/face_recognition
@@ -83,69 +72,14 @@ jobs:
           - perception/object_detection_2d
           - perception/facial_expression_recognition/landmark_based_facial_expression_recognition
           # - perception/object_tracking_3d
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Test Perception Tools
-      run: |
-        ${{ matrix.DEPENDENCIES_INSTALLATION }}
-        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
-  test-control:
-    needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        include:
-          - os: ubuntu-20.04
-            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
-            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
-            export OPENDR_DEVICE=cpu
-            export OPENDR_HOME=$PWD
-            export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
-            export DISABLE_BCOLZ_AVX2=true
-            export ROS_DISTRO="noetic"
-            make install_compilation_dependencies
-            make install_runtime_dependencies
-            pip install -r tests/sources/requirements.txt
-        package:
+        control-package:
           - control/mobile_manipulation
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Test Control Tools
-      run: |
-        ${{ matrix.DEPENDENCIES_INSTALLATION }}
-        source tests/sources/tools/control/mobile_manipulation/run_ros.sh
-        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
-  test-simulation:
-    needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
+        simulation-package:
+          - simulation/human_model_generation
         include:
           - os: ubuntu-20.04
             DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
             && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
-            export OPENDR_DEVICE=cpu
-            export OPENDR_HOME=$PWD
-            export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
-            export DISABLE_BCOLZ_AVX2=true
-            export ROS_DISTRO="noetic"
-            make install_compilation_dependencies
-            make install_runtime_dependencies
-            pip install -r tests/sources/requirements.txt
-        package:
-          - simulation/human_model_generation
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -153,7 +87,28 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Test Simulation Tools
+    - name: Test dependencies
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
-        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
+        export OPENDR_HOME=$PWD
+        export OPENDR_DEVICE=cpu
+        export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
+        export DISABLE_BCOLZ_AVX2=true
+        export ROS_DISTRO=noetic
+        make install_compilation_dependencies
+        make install_runtime_dependencies
+        pip install -r tests/sources/requirements.txt
+        python -m unittest discover -s tests/sources/tools/${{ matrix.engine-package }}
+    - name: Test perception tools
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
+      run: |
+        python -m unittest discover -s tests/sources/tools/${{ matrix.perception-package }}
+    - name: Test control tools
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
+      run: |
+        source tests/sources/tools/control/mobile_manipulation/run_ros.sh
+        python -m unittest discover -s tests/sources/tools/${{ matrix.control-package }}
+    - name: Test simulation tools
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
+      run: |
+        python -m unittest discover -s tests/sources/tools/${{ matrix.simulation-package }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -89,7 +89,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Test Tools
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception') || contains(github.event.pull_request.labels.*.name, 'test control') || contains(github.event.pull_request.labels.*.name, 'test simulation') }}
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception') || contains(github.event.pull_request.labels.*.name, 'test control') || contains(github.event.pull_request.labels.*.name, 'test simulation') }}
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -50,10 +50,11 @@ jobs:
         python -m unittest discover -s tests
   test-tools:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
+        max-parallel: 10
         engine-package:
           - engine
           - utils
@@ -87,7 +88,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Test dependencies
+    - name: Test Tools
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD
@@ -98,17 +100,17 @@ jobs:
         make install_compilation_dependencies
         make install_runtime_dependencies
         pip install -r tests/sources/requirements.txt
-        python -m unittest discover -s tests/sources/tools/${{ matrix.engine-package }}
-    - name: Test perception tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
-      run: |
-        python -m unittest discover -s tests/sources/tools/${{ matrix.perception-package }}
-    - name: Test control tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
-      run: |
-        source tests/sources/tools/control/mobile_manipulation/run_ros.sh
-        python -m unittest discover -s tests/sources/tools/${{ matrix.control-package }}
-    - name: Test simulation tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
-      run: |
-        python -m unittest discover -s tests/sources/tools/${{ matrix.simulation-package }}
+
+        if [ ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }} ]; then
+          python -m unittest discover -s tests/sources/tools/${{ matrix.perception-package }}
+        fi
+
+        if [ ${{ contains(github.event.pull_request.labels.*.name, 'test control') }} ]; then
+          source tests/sources/tools/control/mobile_manipulation/run_ros.sh
+          python -m unittest discover -s tests/sources/tools/${{ matrix.control-package }}
+        fi
+
+        if [ ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }} ]; then
+          python -m unittest discover -s tests/sources/tools/${{ matrix.simulation-package }}
+        fi
+

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -1,4 +1,4 @@
-name: Test Sources
+name: Test Suite
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -50,15 +50,14 @@ jobs:
         python -m unittest discover -s tests
   test-tools:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception') || contains(github.event.pull_request.labels.*.name, 'test control') || contains(github.event.pull_request.labels.*.name, 'test simulation') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
-      max-parallel: 10
+      max-parallel: 8
       matrix:
         os: [ubuntu-20.04]
-        engine-package:
+        package:
           - engine
           - utils
-        perception-package:
           - perception/activity_recognition
           - perception/compressive_learning
           - perception/face_recognition
@@ -70,13 +69,11 @@ jobs:
           - perception/speech_recognition
           - perception/skeleton_based_action_recognition
           - perception/semantic_segmentation
+          - control/mobile_manipulation
           - perception/object_detection_2d
+          - simulation/human_model_generation
           - perception/facial_expression_recognition/landmark_based_facial_expression_recognition
           # - perception/object_tracking_3d
-        control-package:
-          - control/mobile_manipulation
-        simulation-package:
-          - simulation/human_model_generation
         include:
           - os: ubuntu-20.04
             DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
@@ -89,7 +86,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Test Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception') || contains(github.event.pull_request.labels.*.name, 'test control') || contains(github.event.pull_request.labels.*.name, 'test simulation') }}
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD
@@ -100,17 +97,10 @@ jobs:
         make install_compilation_dependencies
         make install_runtime_dependencies
         pip install -r tests/sources/requirements.txt
-
-        if [ ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }} ]; then
-          python -m unittest discover -s tests/sources/tools/${{ matrix.perception-package }}
-        fi
-
-        if [ ${{ contains(github.event.pull_request.labels.*.name, 'test control') }} ]; then
-          source tests/sources/tools/control/mobile_manipulation/run_ros.sh
-          python -m unittest discover -s tests/sources/tools/${{ matrix.control-package }}
-        fi
-
-        if [ ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }} ]; then
-          python -m unittest discover -s tests/sources/tools/${{ matrix.simulation-package }}
+        if [ ${{ matrix.package }} = "ctests" ]; then
+            make ctests
+        else
+            source tests/sources/tools/control/mobile_manipulation/run_ros.sh
+            python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
         fi
 

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -89,7 +89,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Test Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception') || contains(github.event.pull_request.labels.*.name, 'test control') || contains(github.event.pull_request.labels.*.name, 'test simulation') }}
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -53,12 +53,8 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         include:
-          - os: ubuntu-18.04
-            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
-            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
-            ROS_DISTRO: "melodic"
           - os: ubuntu-20.04
             DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
             && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') || contains(github.event.pull_request.labels.*.name, 'test dependencies')}}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -78,36 +78,61 @@ jobs:
         make install_compilation_dependencies
         make install_runtime_dependencies
         pip install -r tests/sources/requirements.txt
-  test-tools:
+        python -m unittest discover -s tests/sources/tools/engine
+        python -m unittest discover -s tests/sources/tools/utils
+  test-perception:
     needs: test-dependencies
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
         package:
-          - engine
-          - utils
-          - perception/activity_recognition
-          - perception/compressive_learning
-          - perception/face_recognition
-          - perception/heart_anomaly_detection
-          - perception/multimodal_human_centric
-          - perception/object_tracking_2d
-          - perception/object_detection_3d
-          - perception/pose_estimation
-          - perception/speech_recognition
-          - perception/skeleton_based_action_recognition
-          - perception/semantic_segmentation
-          - control/mobile_manipulation
-          - perception/object_detection_2d
-          - simulation/human_model_generation
-          - perception/facial_expression_recognition/landmark_based_facial_expression_recognition
+          - activity_recognition
+          - compressive_learning
+          - face_recognition
+          - heart_anomaly_detection
+          - multimodal_human_centric
+          - object_tracking_2d
+          - object_detection_3d
+          - pose_estimation
+          - speech_recognition
+          - skeleton_based_action_recognition
+          - semantic_segmentation
+          - object_detection_2d
+          - facial_expression_recognition/landmark_based_facial_expression_recognition
           # - perception/object_tracking_3d
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Test Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
-      run: |
+    - name: Test Perception Tools
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
+      run:
+        python -m unittest discover -s tests/sources/tools/perception/${{ matrix.package }}
+  test-control:
+    needs: test-dependencies
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        package:
+          - mobile_manipulation
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Test Control Tools
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
+      run:
         source tests/sources/tools/control/mobile_manipulation/run_ros.sh
-        python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
-
+        python -m unittest discover -s tests/sources/tools/control/${{ matrix.package }}
+  test-simulation:
+    needs: test-dependencies
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        package:
+          - human_model_generation
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Test Simulation Tools
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
+      run:
+        python -m unittest discover -s tests/sources/tools/simulation/${{ matrix.package }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -50,7 +50,7 @@ jobs:
         python -m unittest discover -s tests
   test-tools:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') || contains(github.event.pull_request.labels.*.name, 'test perception' || contains(github.event.pull_request.labels.*.name, 'test control' || contains(github.event.pull_request.labels.*.name, 'test simulation')}}
     strategy:
       max-parallel: 10
       matrix:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -1,4 +1,4 @@
-name: Test Sources
+name: Test Suite
 
 on:
   pull_request:
@@ -48,9 +48,9 @@ jobs:
         export OPENDR_DEVICE=cpu
         pip install -r tests/requirements.txt
         python -m unittest discover -s tests
-  test-dependencies:
+  test-perception:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -58,35 +58,17 @@ jobs:
           - os: ubuntu-20.04
             DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
             && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
-            ROS_DISTRO: "noetic"
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Test Dependencies
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test dependencies') }}
-      run: |
-        ${{ matrix.DEPENDENCIES_INSTALLATION }}
-        export OPENDR_HOME=$PWD
-        export OPENDR_DEVICE=cpu
-        export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
-        export DISABLE_BCOLZ_AVX2=true
-        export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-        make install_compilation_dependencies
-        make install_runtime_dependencies
-        pip install -r tests/sources/requirements.txt
-        python -m unittest discover -s tests/sources/tools/engine
-        python -m unittest discover -s tests/sources/tools/utils
-  test-perception:
-    needs: test-dependencies
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
+            export OPENDR_DEVICE=cpu
+            export OPENDR_HOME=$PWD
+            export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
+            export DISABLE_BCOLZ_AVX2=true
+            export ROS_DISTRO="noetic"
+            make install_compilation_dependencies
+            make install_runtime_dependencies
+            pip install -r tests/sources/requirements.txt
         package:
+          - engine
+          - utils
           - perception/activity_recognition
           - perception/compressive_learning
           - perception/face_recognition
@@ -109,35 +91,69 @@ jobs:
       with:
         python-version: 3.8
     - name: Test Perception Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test perception') }}
-      run:
+      run: |
+        ${{ matrix.DEPENDENCIES_INSTALLATION }}
         python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
   test-control:
-    needs: test-dependencies
+    needs: cleanup-runs
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
+        include:
+          - os: ubuntu-20.04
+            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
+            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
+            export OPENDR_DEVICE=cpu
+            export OPENDR_HOME=$PWD
+            export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
+            export DISABLE_BCOLZ_AVX2=true
+            export ROS_DISTRO="noetic"
+            make install_compilation_dependencies
+            make install_runtime_dependencies
+            pip install -r tests/sources/requirements.txt
         package:
           - control/mobile_manipulation
     runs-on: ${{ matrix.os }}
     steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - name: Test Control Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test control') }}
-      run:
+      run: |
+        ${{ matrix.DEPENDENCIES_INSTALLATION }}
         source tests/sources/tools/control/mobile_manipulation/run_ros.sh
         python -m unittest discover -s tests/sources/tools/${{ matrix.package }}
   test-simulation:
-    needs: test-dependencies
+    needs: cleanup-runs
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
+        include:
+          - os: ubuntu-20.04
+            DEPENDENCIES_INSTALLATION: "sudo sh -c 'echo \"deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main\" > /etc/apt/sources.list.d/ros-latest.list' \
+            && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -"
+            export OPENDR_DEVICE=cpu
+            export OPENDR_HOME=$PWD
+            export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
+            export DISABLE_BCOLZ_AVX2=true
+            export ROS_DISTRO="noetic"
+            make install_compilation_dependencies
+            make install_runtime_dependencies
+            pip install -r tests/sources/requirements.txt
         package:
-        - simulation/human_model_generation
+          - simulation/human_model_generation
     runs-on: ${{ matrix.os }}
     steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - name: Test Simulation Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test simulation') }}
-      run:
+      run: |
+        ${{ matrix.DEPENDENCIES_INSTALLATION }}
         python -m unittest discover -s tests/sources/tools/${{ matrix.package }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -52,9 +52,9 @@ jobs:
     needs: cleanup-runs
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
+      max-parallel: 10
       matrix:
         os: [ubuntu-20.04]
-        max-parallel: 10
         engine-package:
           - engine
           - utils

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -52,7 +52,7 @@ jobs:
     needs: cleanup-runs
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
-      max-parallel: 12
+      max-parallel: 10
       matrix:
         os: [ubuntu-20.04]
         package:

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -52,7 +52,7 @@ jobs:
     needs: cleanup-runs
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
-      max-parallel: 8
+      max-parallel: 10
       matrix:
         os: [ubuntu-20.04]
         package:

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -52,7 +52,7 @@ jobs:
     needs: cleanup-runs
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
-      max-parallel: 10
+      max-parallel: 12
       matrix:
         os: [ubuntu-20.04]
         package:


### PR DESCRIPTION
I tried a few things but got nowhere, we can restructure the test at a later moment, it's not too important now.

To avoid having too many fails due to memory usage I've lowered limit for parallel runs. It will slow things down a bit, but hopefully it's still faster than having to rerun the tests twice as we have been forced to do lately.

We can rework the test suite when we move to the new repo