### PR TITLE
Move `mobile_manipulation` ws to projects

### DIFF
--- a/docs/reference/mobile-manipulation.md
+++ b/docs/reference/mobile-manipulation.md
@@ -130,7 +130,7 @@ The dependencies for this module automatically set up and compile a catkin works
 To start required ROS nodes, please run the following before using the `MobileRLLearner` class:
 
 ```sh
-source ${OPENDR_HOME}/lib/catkin_ws_mobile_manipulation/devel/setup.bash
+source ${OPENDR_HOME}/projects/control/mobile_manipulation/mobile_manipulation_ws/devel/setup.bash
 roslaunch mobile_manipulation_rl [pr2,tiago]_analytical.launch
 ````
 

--- a/src/opendr/control/mobile_manipulation/install_mobile_manipulation.sh
+++ b/src/opendr/control/mobile_manipulation/install_mobile_manipulation.sh
@@ -11,7 +11,7 @@ if [[ -z "$ROS_DISTRO" ]]; then
 fi
 
 MODULE_PATH=${OPENDR_HOME}/src/opendr/control/mobile_manipulation
-WS_PATH=${OPENDR_HOME}/lib/catkin_ws_mobile_manipulation
+WS_PATH=${OPENDR_HOME}/projects/control/mobile_manipulation/mobile_manipulation_ws
 
 ## ROS
 sudo apt-get update && sudo apt-get install -y \

--- a/tests/sources/tools/control/mobile_manipulation/run_ros.sh
+++ b/tests/sources/tools/control/mobile_manipulation/run_ros.sh
@@ -1,4 +1,4 @@
-source ${OPENDR_HOME}/lib/catkin_ws_mobile_manipulation/devel/setup.bash
+source ${OPENDR_HOME}/projects/control/mobile_manipulation/mobile_manipulation_ws/devel/setup.bash
 roscore &
 sleep 5
 roslaunch mobile_manipulation_rl pr2_analytical.launch &


### PR DESCRIPTION
It makes more sense to have the workspaces in the projects folder rather than in the lib folder